### PR TITLE
Wrong repo name in issue link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Here's a list of some of repos with "hacktoberfest" labeled Issues:
 
 ## paypal
 - https://github.com/paypal/paypal-checkout-components ([Issues](https://github.com/paypal/paypal-checkout-components/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest))
-- https://github.com/paypal/paypal-js ([Issues](https://github.com/paypal/paypal-checkout-components/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest))
+- https://github.com/paypal/paypal-js ([Issues](https://github.com/paypal/paypal-js/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest))
 
 ## kraken-js
 - https://github.com/krakenjs/zoid ([Issues](https://github.com/krakenjs/zoid/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest))


### PR DESCRIPTION
Hello,

One of the repo name was wrong when I clicked on it.